### PR TITLE
Refactor `smr.algorithm.SemanticMatchGraph` to deal with multiple metrics

### DIFF
--- a/semantic_match_registry/pyproject.toml
+++ b/semantic_match_registry/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "semantic_match_registry"
-version = "0.1.0"
-description = "A prototype Semantic Match Registry implemented in Python"
+version = "1.0.0"
+description = "A Semantic Match Registry implemented in Python"
 readme = "README.md"
 requires-python = ">=3.11"
 authors = [{ name = "Sebastian Heppner", email = "mail@s-heppner.com" }]

--- a/semantic_match_registry/tests/test_resources/example_graph.json
+++ b/semantic_match_registry/tests/test_resources/example_graph.json
@@ -1,20 +1,34 @@
-[
-    {
-        "base_semantic_id": "https://s-heppner.com/semantic_id/one",
-        "match_semantic_id": "https://s-heppner.com/semantic_id/uno",
-        "score": 0.9,
-        "path": []
-    },
-    {
-        "base_semantic_id": "https://s-heppner.com/semantic_id/one",
-        "match_semantic_id": "https://remote.com/semantic_id/deux",
-        "score": 0.7,
-        "path": []
-    },
-    {
-        "base_semantic_id": "https://s-heppner.com/semantic_id/uno",
-        "match_semantic_id": "https://s-heppner.com/semantic_id/trois",
-        "score": 0.6,
-        "path": []
-    }
-]
+{
+    "nodes": [
+        "https://s-heppner.com/semantic_id/one",
+        "https://s-heppner.com/semantic_id/uno",
+        "https://s-heppner.com/semantic_id/trois",
+        "https://remote.com/semantic_id/deux"
+    ],
+    "edges": [
+        {
+            "u": "https://s-heppner.com/semantic_id/one",
+            "v": "https://s-heppner.com/semantic_id/uno",
+            "weight": 0.9,
+            "metric_scores": {
+                "_no_metric_id": 0.9
+            }
+        },
+        {
+            "u": "https://s-heppner.com/semantic_id/one",
+            "v": "https://remote.com/semantic_id/deux",
+            "weight": 0.7,
+            "metric_scores": {
+                "_no_metric_id": 0.7
+            }
+        },
+        {
+            "u": "https://s-heppner.com/semantic_id/uno",
+            "v": "https://s-heppner.com/semantic_id/trois",
+            "weight": 0.6,
+            "metric_scores": {
+                "_no_metric_id": 0.6
+            }
+        }
+    ]
+}

--- a/semantic_match_registry/tests/test_service.py
+++ b/semantic_match_registry/tests/test_service.py
@@ -18,7 +18,7 @@ import json as js
 
 
 def run_server():
-    # Read in equivalence table
+    # Read in graph (new {"nodes":..., "edges":...} schema)
     match_graph = algorithm.SemanticMatchGraph.from_file(
         filename=os.path.abspath(os.path.join(
             os.path.dirname(__file__),
@@ -26,43 +26,41 @@ def run_server():
         ))
     )
 
-    # Initialise SemanticMatchRegistry
+    # Init service
     semantic_matching_service = SemanticMatchRegistry(
         endpoint="localhost",
         graph=match_graph
     )
 
-    # Mock semantic_id Resolver
+    # Mock resolver
     def mock_get_matcher(self, semantic_id):
         return "http://remote-service:8000"
-
     SemanticMatchRegistry._get_matcher_from_semantic_id = mock_get_matcher
 
-    # Mock remote service
-    original_requests_get = requests.get
+    # Mock remote service POST /query_matches to return a list of matches
+    original_requests_post = requests.post
 
     class SimpleResponse:
-        def __init__(self, content: str, status_code: int = 200):
-            self.text = content
+        def __init__(self, obj, status_code=200):
+            self._obj = obj
             self.status_code = status_code
 
-    def mock_requests_get(url, json):
-        if url == "http://remote-service:8000/get_matches":
+        def json(self):
+            return self._obj
+
+    def mock_requests_post(url, json=None, **kwargs):
+        if url == "http://remote-service:8000/query_matches":
             match_one = algorithm.SemanticMatch(
                 base_semantic_id="s-heppner.com/semanticID/three",
                 match_semantic_id="remote-service.com/semanticID/tres",
                 score=1.0,
                 path=[]
             )
-            matches_data = {
-                "matches": [match_one.model_dump()]
-            }
-            matches_json = js.dumps(matches_data)
-            return SimpleResponse(content=matches_json)
-        else:
-            return original_requests_get(url, json=json)
+            # Server expects a plain list response now
+            return SimpleResponse([match_one.model_dump()])
+        return original_requests_post(url, json=json, **kwargs)
 
-    requests.get = mock_requests_get
+    requests.post = mock_requests_post
 
     # Run server
     app = FastAPI()
@@ -86,26 +84,6 @@ def run_server_context():
 
 
 class TestSemanticMatchRegistry(unittest.TestCase):
-    def test_get_all_matches(self):
-        with run_server_context():
-            response = requests.get("http://localhost:8000/all_matches")
-            expected_matches = [
-                {'base_semantic_id': 'https://s-heppner.com/semantic_id/one',
-                 'match_semantic_id': 'https://s-heppner.com/semantic_id/uno',
-                 'path': [],
-                 'score': 0.9},
-                {'base_semantic_id': 'https://s-heppner.com/semantic_id/one',
-                 'match_semantic_id': 'https://remote.com/semantic_id/deux',
-                 'path': [],
-                 'score': 0.7},
-                {'base_semantic_id': 'https://s-heppner.com/semantic_id/uno',
-                 'match_semantic_id': 'https://s-heppner.com/semantic_id/trois',
-                 'path': [],
-                 'score': 0.6}
-            ]
-            actual_matches = response.json()
-            self.assertEqual(expected_matches, actual_matches)
-
     def test_post_matches(self):
         with run_server_context():
             new_match = {
@@ -121,31 +99,29 @@ class TestSemanticMatchRegistry(unittest.TestCase):
             self.assertEqual(200, response.status_code)
             # Todo: Make sure this does not become a problem in other tests
 
-    def test_get_matches_local_only(self):
+    def test_get_all_matches(self):
         with run_server_context():
-            match_request = {
-                "semantic_id": "https://s-heppner.com/semantic_id/one",
-                "score_limit": 0.5,
-                "local_only": True
+            resp = requests.get("http://localhost:8000/all_matches")
+            self.assertEqual(resp.status_code, 200)
+            data = resp.json()
+            # It now returns SemanticMatch dicts including metric_id and graph_score
+            self.assertIsInstance(data, list)
+            self.assertTrue(all(isinstance(x, dict) for x in data))
+
+            # We expect at least these direct edges to exist (ignoring metric_id multiplicity):
+            must_have = {
+                ("https://s-heppner.com/semantic_id/one", "https://s-heppner.com/semantic_id/uno", 0.9),
+                ("https://s-heppner.com/semantic_id/one", "https://remote.com/semantic_id/deux", 0.7),
+                ("https://s-heppner.com/semantic_id/uno", "https://s-heppner.com/semantic_id/trois", 0.6),
             }
-            response = requests.get("http://localhost:8000/get_matches", json=match_request)
-            expected_matches = [
-                {'base_semantic_id': 'https://s-heppner.com/semantic_id/one',
-                 'match_semantic_id': 'https://s-heppner.com/semantic_id/uno',
-                 'path': ['https://s-heppner.com/semantic_id/one'],
-                 'score': 0.9},
-                {'base_semantic_id': 'https://s-heppner.com/semantic_id/one',
-                 'match_semantic_id': 'https://remote.com/semantic_id/deux',
-                 'path': ['https://s-heppner.com/semantic_id/one'],
-                 'score': 0.7},
-                {'base_semantic_id': 'https://s-heppner.com/semantic_id/one',
-                 'match_semantic_id': 'https://s-heppner.com/semantic_id/trois',
-                 'path': ['https://s-heppner.com/semantic_id/one',
-                          'https://s-heppner.com/semantic_id/uno'],
-                 'score': 0.54}
-            ]
-            actual_matches = response.json()
-            self.assertEqual(expected_matches, actual_matches)
+            triples = {(d["base_semantic_id"], d["match_semantic_id"], round(float(d["score"]), 10)) for d in data}
+            for t in must_have:
+                self.assertIn(t, triples, f"Missing expected match {t}")
+
+            # graph_score should always be present and numeric
+            for d in data:
+                self.assertIn("graph_score", d)
+                self.assertIsInstance(d["graph_score"], (int, float))
 
     def test_get_matches_local_and_remote(self):
         with run_server_context():
@@ -154,19 +130,21 @@ class TestSemanticMatchRegistry(unittest.TestCase):
                 "score_limit": 0.7,
                 "local_only": False
             }
-            response = requests.get("http://localhost:8000/get_matches", json=match_request)
-            expected_matches = [
-                {'base_semantic_id': 'https://s-heppner.com/semantic_id/one',
-                 'match_semantic_id': 'https://s-heppner.com/semantic_id/uno',
-                 'path': ['https://s-heppner.com/semantic_id/one'],
-                 'score': 0.9},
-                {'base_semantic_id': 'https://s-heppner.com/semantic_id/one',
-                 'match_semantic_id': 'https://remote.com/semantic_id/deux',
-                 'path': ['https://s-heppner.com/semantic_id/one'],
-                 'score': 0.7}
-            ]
-            actual_matches = response.json()
-            self.assertEqual(expected_matches, actual_matches)
+            resp = requests.post("http://localhost:8000/query_matches", json=match_request)
+            self.assertEqual(resp.status_code, 200)
+            data = resp.json()
+
+            # Must include the two local single-edge matches >= 0.7
+            want_local = {
+                ("https://s-heppner.com/semantic_id/one", "https://s-heppner.com/semantic_id/uno", 0.9),
+                ("https://s-heppner.com/semantic_id/one", "https://remote.com/semantic_id/deux", 0.7),
+            }
+            triples = {(d["base_semantic_id"], d["match_semantic_id"], round(float(d["score"]), 10)) for d in data}
+            for t in want_local:
+                self.assertIn(t, triples)
+
+            # Remote mock may add extra entries; just ensure list shape is sane
+            self.assertTrue(all(isinstance(x, dict) for x in data))
 
     def test_get_matches_no_matches(self):
         with run_server_context():
@@ -175,9 +153,9 @@ class TestSemanticMatchRegistry(unittest.TestCase):
                 "score_limit": 0.5,
                 "local_only": True
             }
-            response = requests.get("http://localhost:8000/get_matches", json=match_request)
-            actual_matches = response.json()
-            self.assertEqual([], actual_matches)
+            resp = requests.post("http://localhost:8000/query_matches", json=match_request)
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual([], resp.json())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Previously, `smr.algorithm.SemanticMatchGraph` only allowed for one edge between two nodes (as it inherits from `nx.DiGraph`). This was expected in a sense, because the *graph implied* semantic model only works with one edge per set of nodes.

However, my concept allows for two nodes be connected by multiple edges, representing semantic similarity scores from different matching methods (e.g. *semantic similarity metrics*, as I call them). A user would want all of them reported.

To fix this apparent mismatch of requirements, I implemented the following:

- We keep the `nx.DiGraph` structure as is, as all the other algorithms rely on it, and it only makes sense for the *graph implied* semantic model.
- The `weight` of the edge is always the one all the algorithms work with (similarly how the `smr_alignment.TriangleViolationChecker` writes the "repaired" similarity scores to the `weight`).
- We store additional similarity scores in a `Dict[metric_id: score]` called `metric_scores` (or similar) as an additional attribute of the edge.
- When adding a new score to an existing edge, choose `max(metric_scores.values)` as new `weight`, as this minimizes the triangle inequality violation of this metric and this is the one the `TriangleViolationChecker` would choose always anyway (if we implemented a Dijkstra or Floyd-Warshall that could deal with parallel edges).

This change necessitated a rat's tail of other changes:

- `algorithm.SemanticMatchGraph.to_file()` now stores the actual graph in the file, not a list of `SemanticMatch`es. `algorithm.SemanticMatchGraph.from_file()` is adapted accordingly. This is **backward incompatible**!
- We adapt `algorithm.SemanticMatch` with two new attributes:
  - `metric_id`: Globally identifying string of the metric used (e.g. the NLP model + version)
  - `graph_score`: The score that was considered in the SemanticMatchGraph's search algorithm. This value can be ignored in most cases and is more interesting as a debug information. It might explain why a SemanticMatch with this score was returned by the query, even though the score might not fit.
- We adapt `service` to deal with the changed data structures
- We adapt the unittests accordingly

Not strictly necessary, but while we were at it, we also changed the `get_matches` endpoint to `query_matches`, since GET was wrong from an HTTP specification point of view. We're not getting static data, but performing a computation.

We bump the version of `semantic_match_registry` to `1.0.0` in the `pyproject.toml`, not because it is now considered stable, but rather because of semantic versioning and this being a backward incompatible change.

Fixes #10