### PR TITLE
algorithm: Fix non-starting-node loops

### DIFF
--- a/semantic_match_registry/src/smr/algorithm.py
+++ b/semantic_match_registry/src/smr/algorithm.py
@@ -206,8 +206,12 @@ def find_semantic_matches(
 
         # Traverse to the neighboring and therefore connected `semantic_id`s
         for neighbor, edge_data in graph[node].items():
-            if path and neighbor == path[-1]:
-                continue  # avoid immediate backtrack A->B->A ping-pong
+            # Avoid any cycle: no revisiting nodes that are already in this path
+            # Note: `path` holds all previous nodes; `node` is *not* yet in `path`
+            # This also lets us avoid immediate backtrack A->B->A ping-pong for free
+            if neighbor in path or neighbor == node:
+                continue
+
             edge_weight = float(edge_data.get("weight", 0.0))
             new_score: float = score * edge_weight  # Multiplicative propagation
 


### PR DESCRIPTION
Previously, there was a bug that potentially caused non-termination of the algorithm. If there was a loop that did not include the starting node, and the `min_score` was sufficiently low, the algorithm could return an arbitrarily large number of paths going round and round that loop.

While these paths are technically valid matches, they are not really constructive, in a sense that they do repeat the nodes that they match, just with different weights. Furthermore, it is necessary from a technical point of view to avoid them so that the algorithm terminates.

This adds an additional check that the current path does not run into such a loop, as well as the corresponding unittest to check that it works as intended.